### PR TITLE
🔇  Fix warning from selected dropdown

### DIFF
--- a/src/components/inputs/input-select/InputSelect.tsx
+++ b/src/components/inputs/input-select/InputSelect.tsx
@@ -23,16 +23,14 @@ export const MbInputSelect = (props: SelectProps) => {
     >
       <select
         id="select"
+        value={value}
         className="select-field appearance-none relative z-10"
         disabled={disabled}
         onChange={(event) => onValueChange(event.target.value)}
         {...restProps}
       >
         {options.map((option) => (
-          <option 
-            value={option.value}
-            selected={option.value === value}
-          >
+          <option value={option.value}>
             {option.label}
           </option>
         ))}


### PR DESCRIPTION
Fixes this warning:
```Warning: Use the `defaultValue` or `value` props on <select> instead of setting `selected` on <option>```