### PR TITLE
🩹 Extending tooltip with extraprops

### DIFF
--- a/src/components/tooltip/Tooltip.tsx
+++ b/src/components/tooltip/Tooltip.tsx
@@ -7,11 +7,13 @@ export const MbTooltip = ({
   id,
   place = 'bottom',
   component,
+  extraProps = {}
 }: {
   text: string
   id: string
   place: Place
   component: JSX.Element
+  extraProps?: Record<string, any>
 }) => {
   return (
     <>
@@ -30,6 +32,7 @@ export const MbTooltip = ({
         getContent={() => {
           return <span className="cap-big-90">{text}</span>
         }}
+        {...extraProps}
       />
     </>
   )


### PR DESCRIPTION
Looks off in the storybook, but now displaying properly on the website:

![Screenshot 2022-04-08 at 14 23 31](https://user-images.githubusercontent.com/31419678/162444579-87b6f9a2-0f3e-4d91-8716-b72f5288730b.png)
 