### PR TITLE
:sparkles: Add Extra Prop in Thing Card for Store Name

### DIFF
--- a/src/components/cards/thing/ThingCard.tsx
+++ b/src/components/cards/thing/ThingCard.tsx
@@ -41,6 +41,7 @@ export const MbThingCard = ({ loading = false, cardInfo }: CardProps) => {
     upperRightElement,
     centerElement,
     nftTypeIcon,
+    extraMidLeftElement,
     midLeftText,
     midRightText,
     botLeftImage,
@@ -90,7 +91,10 @@ export const MbThingCard = ({ loading = false, cardInfo }: CardProps) => {
           <div className="absolute inset-0">{centerElement}</div>
         </div>
       </div>
-      <div className="flex flex-row justify-between text-black dark:text-white mt-12">
+      <div className="p-med-90 text-gray-700 dark:text-gray-300 mt-12 w-5/6 truncate">
+        {extraMidLeftElement}
+      </div>
+      <div className="flex flex-row justify-between text-black dark:text-white mt-8">
         <div className="p-big-90 w-52 truncate">{midLeftText}</div>
         <div className="p-big-90 text-right break-all">{midRightText}</div>
       </div>

--- a/src/stories/components/cards/ThingCard.stories.tsx
+++ b/src/stories/components/cards/ThingCard.stories.tsx
@@ -7,7 +7,7 @@ import { MbIcon } from '../../../components/icon/Icon'
 import { EIconName } from '../../../consts/icons'
 
 export default {
-  title: 'Components/Cards',
+  title: 'Components/Cards/Thing',
   component: MbThingCard,
   argTypes: {},
 } as ComponentMeta<typeof MbThingCard>
@@ -65,6 +65,43 @@ Thing.args = {
       />
     ),
     nftTypeIcon: EIconName.IMAGE,
+    midLeftText: 'Thing Name',
+    midRightText: '10 N',
+    botLeftImage:
+      'https://coldcdn.com/api/cdn/bronil/JXl58b_p9iYzeFutFC5GcDCjsxppyFt5rRkQt4Su4LU',
+    botRightText: '5/10',
+    botRightIcon: EIconName.EDITIONS,
+    onBotLeftImageClick: () => null,
+    onCenterElementClick: () => null,
+    onUpperLeftClick: () => null,
+    onUpperRightClick: () => null,
+  },
+  loading: false,
+}
+
+export const ThingWithStoreName = Template.bind({})
+ThingWithStoreName.args = {
+  cardInfo: {
+    upperLeftText: '1',
+    upperRightElement: <Icon></Icon>,
+    centerElement: (
+      <img
+        className="h-full w-full object-cover"
+        src="https://coldcdn.com/api/cdn/bronil/JXl58b_p9iYzeFutFC5GcDCjsxppyFt5rRkQt4Su4LU"
+      />
+    ),
+    nftTypeIcon: EIconName.IMAGE,
+    extraMidLeftElement: (
+      <div className="flex gap-4 items-center">
+        <p>Store Name</p>{' '}
+        <MbIcon
+          name={EIconName.VERIFIED}
+          size="16px"
+          color="blue-300"
+          darkColor="blue-100"
+        />
+      </div>
+    ),
     midLeftText: 'Thing Name',
     midRightText: '10 N',
     botLeftImage:

--- a/src/types/cards.type.ts
+++ b/src/types/cards.type.ts
@@ -7,6 +7,7 @@ export type TThingCard = {
   upperRightElement?: JSX.Element
   centerElement: JSX.Element
   nftTypeIcon?: EIconName
+  extraMidLeftElement?: JSX.Element
   midLeftText: string
   midRightText: string
   botLeftImage?: string


### PR DESCRIPTION
Added Thing Card that receives a store name && icon.

![Screenshot 2022-06-30 at 10 26 31](https://user-images.githubusercontent.com/11164548/176642665-7291ab0d-9566-4a9c-8117-3822a5b52979.png)
